### PR TITLE
Task/refactor application start

### DIFF
--- a/gardien_os/config/target.exs
+++ b/gardien_os/config/target.exs
@@ -49,19 +49,19 @@ config :vintage_net,
        ipv4: %{method: :dhcp}
      }},
     {"wlan0",
-      %{
-        type: VintageNetWiFi,
-        vintage_net_wifi: %{
-          networks: [
-            %{
-              key_mgmt: :wpa_psk,
-              ssid: "",
-              psk: ""
-            }
-          ]
-        },
-        ipv4: %{method: :dhcp},
-      }}
+     %{
+       type: VintageNetWiFi,
+       vintage_net_wifi: %{
+         networks: [
+           %{
+             key_mgmt: :wpa_psk,
+             ssid: "",
+             psk: ""
+           }
+         ]
+       },
+       ipv4: %{method: :dhcp}
+     }}
   ]
 
 config :mdns_lite,

--- a/gardien_os/lib/blink.ex
+++ b/gardien_os/lib/blink.ex
@@ -2,7 +2,7 @@ defmodule Blinky.Blink do
   use GenServer
 
   def start_link() do
-      GenServer.start_link(__MODULE__, [])
+    GenServer.start_link(__MODULE__, [])
   end
 
   def init([]) do
@@ -22,5 +22,4 @@ defmodule Blinky.Blink do
     Process.send_after(self(), :blink_on, 1000)
     {:noreply, pid}
   end
-
 end

--- a/gardien_os/lib/gardien_os.ex
+++ b/gardien_os/lib/gardien_os.ex
@@ -21,7 +21,7 @@ defmodule GardienOs do
 
     # Define workers and child supervisors to be supervised
     children = [
-      worker(Blinky.Blink, []),
+      worker(Blinky.Blink, [])
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html

--- a/gardien_os/lib/gardien_os.ex
+++ b/gardien_os/lib/gardien_os.ex
@@ -15,18 +15,4 @@ defmodule GardienOs do
   def hello do
     :world
   end
-
-  def start(_type, _args) do
-    import Supervisor.Spec, warn: false
-
-    # Define workers and child supervisors to be supervised
-    children = [
-      worker(Blinky.Blink, [])
-    ]
-
-    # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html
-    # for other strategies and supported options
-    opts = [strategy: :one_for_one, name: Blinky.Supervisor]
-    Supervisor.start_link(children, opts)
-  end
 end

--- a/gardien_os/lib/gardien_os/application.ex
+++ b/gardien_os/lib/gardien_os/application.ex
@@ -9,6 +9,7 @@ defmodule GardienOs.Application do
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: GardienOs.Supervisor]
+
     children =
       [
         # Children for all targets

--- a/gardien_os/lib/gardien_os/application.ex
+++ b/gardien_os/lib/gardien_os/application.ex
@@ -34,6 +34,7 @@ defmodule GardienOs.Application do
       # Children for all targets except host
       # Starts a worker by calling: GardienOs.Worker.start_link(arg)
       # {GardienOs.Worker, arg},
+      Blinky.Blink
     ]
   end
 

--- a/gardien_os/mix.exs
+++ b/gardien_os/mix.exs
@@ -59,7 +59,7 @@ defmodule GardienOs.MixProject do
       {:nerves_system_x86_64, "~> 1.11", runtime: false, targets: :x86_64},
 
       # Simplified GPIO
-      {:elixir_ale, "~> 1.2"},
+      {:elixir_ale, "~> 1.2"}
     ]
   end
 


### PR DESCRIPTION
I hope to give you more meaningful and complete help throughout this week.  But I just wanted to unblock you with the issue of _it won't start on its own_.

I have two commits here:

- The first is the result of running `mix format`.  You should be able to find an auto-formatter for whatever IDE you're using (they typically just run `mix format` for you, on-save).  I personally use VS Code + ElixirLS extension (there may be some additional setting to set to get format on save?  I get anxiety every time I step into vscode's settings for some reason, so I blocked out the memory of setting things up)

- The second one moves the supervision of `Blinky.Blink` into `GardienOs.Application.start/2`.  This is the equivalent of other language's `int main()`.  If there is some new worker/supervisor you want to start, you'd generally start it here.
